### PR TITLE
Fix Heat-Pump Only and Electric Only Modes

### DIFF
--- a/devicetypes/jjhuff/rheem-econet-water-heater.src/rheem-econet-water-heater.groovy
+++ b/devicetypes/jjhuff/rheem-econet-water-heater.src/rheem-econet-water-heater.groovy
@@ -177,11 +177,11 @@ def RequestOff(){
     parent.refresh()
 }
 def RequestHeatPumpOnly(){
-	parent.setDeviceMode(this.device, "Heat Pump Only")
+	parent.setDeviceMode(this.device, "Heat Pump")
     parent.refresh()
 }
 def RequestElectricOnly(){
-	parent.setDeviceMode(this.device, "Electric-Only")
+	parent.setDeviceMode(this.device, "Electric")
     parent.refresh()
 }
 


### PR DESCRIPTION
There has been an API change and the calls now are just "Heat Pump" and "Electric" to change to these modes.